### PR TITLE
feat: add year_created and year_created_source

### DIFF
--- a/scripts/data.json
+++ b/scripts/data.json
@@ -533,7 +533,9 @@
     {
       "name": "Next.js",
       "url": "https://nextjs.org",
-      "type": "Framework"
+      "type": "Framework",
+      "year_created": 2016,
+      "year_created_source": "https://github.com/vercel/next.js/releases/tag/1.0.1"
     },
     {
       "name": "npm",
@@ -879,7 +881,10 @@
     {
       "name": "Vercel",
       "url": "https://vercel.com/",
-      "type": "Deployment"
+      "type": "Deployment",
+      "year_created": 2015,
+      "year_created_source": "https://en.wikipedia.org/wiki/Vercel",
+      "year_created_source_alt": "https://www.businessinsider.com/vercel-zeit-pitch-deck-21-million-accel-github-ceo-2020-4"
     },
     {
       "name": "Video.js",


### PR DESCRIPTION
I've added the "year_created" and "year_created_source" fields to Next.js and Vercel, as per your requirements outlined in the documentation. 
If you could take a moment to review these additions and provide your feedback, I'd greatly appreciate it. If everything looks good to you, I'll proceed with updating more technologies accordingly.