### PR TITLE
feat: automate using GitHub Actions

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -17,15 +17,14 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
-        cache: npm
 
     - name: Generate contents
       run: node scripts/generate.js
 
     - name: Commit and push
       run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
+        git config user.name github-actions[bot]
+        git config user.email 41898282+github-actions[bot]@users.noreply.github.com
         git add .
         git commit -m "chore: generate contents"
         git push

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,31 @@
+name: Generate contents
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  generate:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: npm
+
+    - name: Generate contents
+      run: node scripts/generate.js
+
+    - name: Commit and push
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -m "chore: generate contents"
+        git push


### PR DESCRIPTION
I have written a workflow for automating content generation upon the merging of pull requests. It simply involves making edits to the `data.json`, eliminating the need for manual content generation.

Here is a successful execution of this workflow on my fork:
https://github.com/dnhn/fe-pedia-paradite-actions/actions/runs/5903648824

To ensure the successful pushing of commits through this workflow, it is required that read and write permissions are granted to the workflow in repository Settings > Actions.

<img width="400" alt="" src="https://github.com/paradite/frontend-encyclopedia/assets/2561973/f968f6cc-4e2d-44ce-a299-d4ca2f7a37ea">
